### PR TITLE
MQTT authentication for gateways

### DIFF
--- a/go/as/external/api/gateway.pb.go
+++ b/go/as/external/api/gateway.pb.go
@@ -55,6 +55,8 @@ type Gateway struct {
 	Tags map[string]string `protobuf:"bytes,10,rep,name=tags,proto3" json:"tags,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	// Metadata (provided by the gateway).
 	Metadata             map[string]string `protobuf:"bytes,11,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	//Mqtt Key for gateway authentification
+	MqttKey              string            `protobuf:"bytes,10,opt,name=mqtt_key,json=mqttKey,proto3" json:"mqtt_key,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
 	XXX_unrecognized     []byte            `json:"-"`
 	XXX_sizecache        int32             `json:"-"`
@@ -160,6 +162,13 @@ func (m *Gateway) GetMetadata() map[string]string {
 		return m.Metadata
 	}
 	return nil
+}
+
+func (m *Gateway) GetMqttKey() string {
+	if m != nil {
+		return m.MqttKey
+	}
+	return ""
 }
 
 type GatewayBoard struct {

--- a/protobuf/as/external/api/gateway.proto
+++ b/protobuf/as/external/api/gateway.proto
@@ -112,6 +112,9 @@ message Gateway {
 
     // Metadata (provided by the gateway).
     map<string, string> metadata = 11;
+
+	//Mqtt_key for gateway authentification
+    string mqtt_key = 12;
 }
 
 message GatewayBoard {


### PR DESCRIPTION
We integrated the Mosquitto-Go-Auth plugin from iegomez's work (here is their GitHub: https://github.com/iegomez/mosquitto-go-auth) to allow the MQTT authentication for gateways. This feature adds a new layer of security and the possibility to manage authorizations.

We didn't merge the last commit (75c58cff8f88f9fd7c424fcfaf3939deb19ef4d3) because we had the error below and not enough time to solve it : ![Screenshot 2020-03-16 15-48-01](https://user-images.githubusercontent.com/37622919/76770012-8f4dfa00-679d-11ea-9a17-788341b2f004.png)

In order to apply these changes, a new release of the ChirpStack API must be done.

This pull request comes with two others, on [ChirpStack Docker](https://github.com/brocaar/chirpstack-docker/pull/31) and [ChirpStack Application Server](https://github.com/brocaar/chirpstack-application-server/pull/442) repositories.
